### PR TITLE
Simplified edge to edge

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.2"
+        kotlinCompilerExtensionVersion = "1.5.3"
     }
     packaging {
         resources {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("UnstableApiUsage")
 
 plugins {
     id("com.android.application")
@@ -21,12 +20,12 @@ plugins {
 
 android {
     namespace = "com.example.superheroes"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.example.superheroes"
         minSdk = 24
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
 
@@ -56,7 +55,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.7"
+        kotlinCompilerExtensionVersion = "1.5.2"
     }
     packaging {
         resources {
@@ -66,7 +65,7 @@ android {
 }
 
 dependencies {
-    implementation(platform("androidx.compose:compose-bom:2023.06.00"))
+    implementation(platform("androidx.compose:compose-bom:2023.08.00"))
     implementation("androidx.activity:activity-compose:1.7.2")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")

--- a/app/src/main/java/com/example/superheroes/HeroesScreen.kt
+++ b/app/src/main/java/com/example/superheroes/HeroesScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -63,6 +64,7 @@ import com.example.superheroes.ui.theme.SuperheroesTheme
 fun HeroesList(
     heroes: List<Hero>,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
     val visibleState = remember {
         MutableTransitionState(false).apply {
@@ -80,7 +82,7 @@ fun HeroesList(
         exit = fadeOut(),
         modifier = modifier
     ) {
-        LazyColumn {
+        LazyColumn(contentPadding = contentPadding) {
             itemsIndexed(heroes) { index, hero ->
                 HeroListItem(
                     hero = hero,

--- a/app/src/main/java/com/example/superheroes/MainActivity.kt
+++ b/app/src/main/java/com/example/superheroes/MainActivity.kt
@@ -66,8 +66,7 @@ class MainActivity : ComponentActivity() {
             data source as a dependency and exposes heroes.
              */
             val heroes = HeroesRepository.heroes
-            HeroesList(heroes = heroes, Modifier.padding(it))
-
+            HeroesList(heroes = heroes, contentPadding = it)
         }
     }
 

--- a/app/src/main/java/com/example/superheroes/MainActivity.kt
+++ b/app/src/main/java/com/example/superheroes/MainActivity.kt
@@ -20,7 +20,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -97,4 +96,3 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
-

--- a/app/src/main/java/com/example/superheroes/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/superheroes/ui/theme/Theme.kt
@@ -117,7 +117,7 @@ fun SuperheroesTheme(
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
-            setUpEdgeToEdge(view,darkTheme)
+            setUpEdgeToEdge(view, darkTheme)
         }
     }
 
@@ -137,12 +137,11 @@ private fun setUpEdgeToEdge(view: View, darkTheme: Boolean) {
     val window = (view.context as Activity).window
     WindowCompat.setDecorFitsSystemWindows(window, false)
     window.statusBarColor = Color.Transparent.toArgb()
-    val navigationBarColor = if (Build.VERSION.SDK_INT >= 26) {
-        Color.Transparent.toArgb()
-    }
-    else {
+    val navigationBarColor = when {
+        Build.VERSION.SDK_INT >= 29 -> Color.Transparent.toArgb()
+        Build.VERSION.SDK_INT >= 26 -> Color(0xFF, 0xFF, 0xFF, 0x63).toArgb()
         // Min sdk version for this app is 24, this block is for SDK versions 24 and 25
-        Color(0x63000000).toArgb()
+        else -> Color(0x00,0x00, 0x00, 0x50).toArgb()
     }
     window.navigationBarColor = navigationBarColor
     val controller = WindowCompat.getInsetsController(window, view)

--- a/app/src/main/java/com/example/superheroes/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/superheroes/ui/theme/Theme.kt
@@ -18,6 +18,7 @@ package com.example.superheroes.ui.theme
 
 import android.app.Activity
 import android.os.Build
+import android.view.View
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
@@ -26,6 +27,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -115,9 +117,7 @@ fun SuperheroesTheme(
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.background.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+            setUpEdgeToEdge(view,darkTheme)
         }
     }
 
@@ -127,4 +127,25 @@ fun SuperheroesTheme(
         shapes = Shapes,
         content = content
     )
+}
+
+/**
+ * Sets up edge-to-edge for the window of this [view]. The system icon colors are set to either
+ * light or dark depending on whether the [darkTheme] is enabled or not.
+ */
+private fun setUpEdgeToEdge(view: View, darkTheme: Boolean) {
+    val window = (view.context as Activity).window
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    window.statusBarColor = Color.Transparent.toArgb()
+    val navigationBarColor = if (Build.VERSION.SDK_INT >= 26) {
+        Color.Transparent.toArgb()
+    }
+    else {
+        // Min sdk version for this app is 24, this block is for SDK versions 24 and 25
+        Color(0x63000000).toArgb()
+    }
+    window.navigationBarColor = navigationBarColor
+    val controller = WindowCompat.getInsetsController(window, view)
+    controller.isAppearanceLightStatusBars = !darkTheme
+    controller.isAppearanceLightNavigationBars = !darkTheme
 }

--- a/app/src/main/java/com/example/superheroes/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/superheroes/ui/theme/Theme.kt
@@ -141,7 +141,7 @@ private fun setUpEdgeToEdge(view: View, darkTheme: Boolean) {
         Build.VERSION.SDK_INT >= 29 -> Color.Transparent.toArgb()
         Build.VERSION.SDK_INT >= 26 -> Color(0xFF, 0xFF, 0xFF, 0x63).toArgb()
         // Min sdk version for this app is 24, this block is for SDK versions 24 and 25
-        else -> Color(0x00,0x00, 0x00, 0x50).toArgb()
+        else -> Color(0x00, 0x00, 0x00, 0x50).toArgb()
     }
     window.navigationBarColor = navigationBarColor
     val controller = WindowCompat.getInsetsController(window, view)

--- a/app/src/main/java/com/example/superheroes/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/superheroes/ui/theme/Type.kt
@@ -28,9 +28,9 @@ val Cabin = FontFamily(
     Font(R.font.cabin_regular, FontWeight.Normal),
     Font(R.font.cabin_bold, FontWeight.Bold)
 )
+
 // Set of Material typography styles to start with
 val Typography = Typography(
-
     bodyLarge = TextStyle(
         fontFamily = Cabin,
         fontWeight = FontWeight.Normal,
@@ -38,7 +38,6 @@ val Typography = Typography(
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp
     ),
-
     displayLarge = TextStyle(
         fontFamily = Cabin,
         fontWeight = FontWeight.Normal,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,5 +18,5 @@
 plugins {
     id("com.android.application") version "8.1.1" apply false
     id("com.android.library") version "8.1.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.0.2" apply false
-    id("com.android.library") version "8.0.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.21" apply false
+    id("com.android.application") version "8.1.1" apply false
+    id("com.android.library") version "8.1.1" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Mar 09 16:31:19 PST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This is the reference PR from Meghan: [Woof edge to edge](https://github.com/google-developer-training/basic-android-kotlin-compose-training-woof/pull/46)

Changes in this PR: 

- Simplified the code a bit
- Removed the code for lower SDK versions since the minimum SDK we support is 24
- Deprecated APIs have been replaced with alternate APIs
- Tested the UI on multiple emulator versions
- Fixed content padding issue

 I would appreciate it if you could take a look at these changes and let me know.